### PR TITLE
update jna dependency to v4.2.1

### DIFF
--- a/lib-openjpeg/pom.xml
+++ b/lib-openjpeg/pom.xml
@@ -26,7 +26,7 @@
             <artifactId>snap-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.sun.jna</groupId>
+            <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -270,7 +270,7 @@
             <dependency>
                 <groupId>com.sun.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>3.0.9</version>
+                <version>4.2.1</version>
             </dependency>
 
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -268,12 +268,6 @@
             </dependency>
 
             <dependency>
-                <groupId>com.sun.jna</groupId>
-                <artifactId>jna</artifactId>
-                <version>4.2.1</version>
-            </dependency>
-
-            <dependency>
                 <groupId>org.xeustechnologies</groupId>
                 <artifactId>jtar</artifactId>
                 <version>1.1</version>


### PR DESCRIPTION
updating to v 4.2.1 seem to fix the exception:
```
java.lang.UnsatisfiedLinkError: com.sun.jna.Native.pointerSize()I
    at com.sun.jna.Native.pointerSize(Native Method)
    at com.sun.jna.Native.<clinit>(Native.java:88)
    at org.esa.s2tbx.dataio.Utils$CKernel32.<clinit>(Utils.java:87)
    at org.esa.s2tbx.dataio.Utils.GetShortPathName(Utils.java:45)
    at org.esa.s2tbx.dataio.Utils.GetIterativeShortPathName(Utils.java:54)
    at org.esa.s2tbx.dataio.openjpeg.OpenJpegUtils.getTileLayoutWithOpenJPEG(OpenJpegUtils.java:59)
    at org.esa.s2tbx.dataio.s2.Sentinel2ProductReader.retrieveTileLayoutFromGranuleDirectory(Sentinel2ProductReader.java:230)
    at org.esa.s2tbx.dataio.s2.Sentinel2ProductReader.retrieveTileLayoutFromProduct(Sentinel2ProductReader.java:195)
    at org.esa.s2tbx.dataio.s2.Sentinel2ProductReader.updateTileLayout(Sentinel2Pro
```
