### PR TITLE
Do not put JP2TileOpImage images into the tile cache.

### DIFF
--- a/s2tbx-jp2-reader/src/main/java/org/esa/s2tbx/dataio/jp2/internal/JP2TileOpImage.java
+++ b/s2tbx-jp2-reader/src/main/java/org/esa/s2tbx/dataio/jp2/internal/JP2TileOpImage.java
@@ -115,7 +115,9 @@ public class JP2TileOpImage extends SingleBandedOpImage {
         Assert.notNull(tileLayout, "imageLayout");
         Assert.notNull(imageModel, "imageModel");
         if (imageFile != null) {
-            return new JP2TileOpImage(imageFile, bandIdx, cacheDir, row, col, tileLayout, imageModel, dataType, level);
+            JP2TileOpImage jp2TileOpImage = new JP2TileOpImage(imageFile, bandIdx, cacheDir, row, col, tileLayout, imageModel, dataType, level);
+            jp2TileOpImage.setTileCache(null); // the MosaicOpImage will be in the cache
+            return jp2TileOpImage;
         } else {
             int targetWidth = tileLayout.tileWidth;
             int targetHeight = tileLayout.tileHeight;


### PR DESCRIPTION
The MosaicOpImage that contains all these images will be in the cache, too.
One of both is enough.