### PR TITLE
modules in toolboxes should not be marked as essential. Hinders deinstallation

### DIFF
--- a/lib-gdal/src/main/nbm/manifest.mf
+++ b/lib-gdal/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: true
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Long-Description: <p>This modules provides some GDAL binaries for use with GDAL readers and writers.

--- a/lib-openjpeg/src/main/nbm/manifest.mf
+++ b/lib-openjpeg/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Long-Description: <p>This modules provides the OpenJPEG codec for compressing and decompressing JPEG2000 files.

--- a/s2tbx-biophysical/src/main/nbm/manifest.mf
+++ b/s2tbx-biophysical/src/main/nbm/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}

--- a/s2tbx-cache-ui/src/main/nbm/manifest.mf
+++ b/s2tbx-cache-ui/src/main/nbm/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false

--- a/s2tbx-cache/src/main/nbm/manifest.mf
+++ b/s2tbx-cache/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Long-Description: <p>This module enables the cache management of Sentinel-2 Toolbox</p>

--- a/s2tbx-commons/src/main/nbm/manifest.mf
+++ b/s2tbx-commons/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Layer: org/esa/snap/ui/layer.xml
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox

--- a/s2tbx-deimos-reader/src/main/nbm/manifest.mf
+++ b/s2tbx-deimos-reader/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Layer: org/esa/s2tbx/dataio/deimos/layer.xml
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox

--- a/s2tbx-gdal-reader-ui/src/main/nbm/manifest.mf
+++ b/s2tbx-gdal-reader-ui/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: true
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Long-Description: <p>This module enables the Sentinel Toolbox to write GDAL products</p>

--- a/s2tbx-gdal-reader/src/main/nbm/manifest.mf
+++ b/s2tbx-gdal-reader/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: true
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Long-Description: <p>This module enables the Sentinel Toolbox to read GDAL products</p>

--- a/s2tbx-jp2-reader/src/main/nbm/manifest.mf
+++ b/s2tbx-jp2-reader/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Layer: org/esa/s2tbx/dataio/jp2/layer.xml

--- a/s2tbx-jp2-writer/src/main/nbm/manifest.mf
+++ b/s2tbx-jp2-writer/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Layer: org/esa/s2tbx/dataio/jp2/layer.xml

--- a/s2tbx-preferences-ui/src/main/nbm/manifest.mf
+++ b/s2tbx-preferences-ui/src/main/nbm/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false

--- a/s2tbx-radiometric-indices/src/main/nbm/manifest.mf
+++ b/s2tbx-radiometric-indices/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: true
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Long-Description: <p>Sentinel-2 Toolbox Radiometric Indices calculus.</p>

--- a/s2tbx-rapideye-reader/src/main/nbm/manifest.mf
+++ b/s2tbx-rapideye-reader/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Layer: org/esa/s2tbx/dataio/rapideye/layer.xml
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox

--- a/s2tbx-s2msi-aerosol-retrieval/src/main/nbm/manifest.mf
+++ b/s2tbx-s2msi-aerosol-retrieval/src/main/nbm/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}

--- a/s2tbx-s2msi-idepix-ui/src/main/nbm/manifest.mf
+++ b/s2tbx-s2msi-idepix-ui/src/main/nbm/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}

--- a/s2tbx-s2msi-idepix/src/main/nbm/manifest.mf
+++ b/s2tbx-s2msi-idepix/src/main/nbm/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}

--- a/s2tbx-s2msi-mci-ui/src/main/nbm/manifest.mf
+++ b/s2tbx-s2msi-mci-ui/src/main/nbm/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}

--- a/s2tbx-s2msi-mci/src/main/nbm/manifest.mf
+++ b/s2tbx-s2msi-mci/src/main/nbm/manifest.mf
@@ -1,6 +1,6 @@
 Manifest-Version: 1.0
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}

--- a/s2tbx-s2msi-reader-ui/src/main/nbm/manifest.mf
+++ b/s2tbx-s2msi-reader-ui/src/main/nbm/manifest.mf
@@ -3,4 +3,4 @@ OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false

--- a/s2tbx-s2msi-reader/src/main/nbm/manifest.mf
+++ b/s2tbx-s2msi-reader/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Layer: org/esa/s2tbx/dataio/s2/layer.xml
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox

--- a/s2tbx-spot-reader/src/main/nbm/manifest.mf
+++ b/s2tbx-spot-reader/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Layer: org/esa/s2tbx/dataio/spot/layer.xml
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox

--- a/s2tbx-spot6-reader/src/main/nbm/manifest.mf
+++ b/s2tbx-spot6-reader/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Layer: org/esa/s2tbx/dataio/spot6/layer.xml
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox

--- a/s2tbx-sta-adapters-help/src/main/nbm/manifest.mf
+++ b/s2tbx-sta-adapters-help/src/main/nbm/manifest.mf
@@ -1,7 +1,7 @@
 Manifest-Version: 1.0
 OpenIDE-Module-Specification-Version: ${project.nbmSpecVersion}
 AutoUpdate-Show-In-Client: false
-AutoUpdate-Essential-Module: true
+AutoUpdate-Essential-Module: false
 OpenIDE-Module-Java-Dependencies: Java > 1.8
 OpenIDE-Module-Display-Category: Sentinel-2 Toolbox
 OpenIDE-Module-Long-Description: S2TBX Adapters Help


### PR DESCRIPTION
modules in toolboxes should not be marked as essential. Hinders deinstallation