### PR TITLE
The MosaicOpImages should be in the tile cache

### DIFF
--- a/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/ortho/Sentinel2OrthoProductReader.java
+++ b/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/ortho/Sentinel2OrthoProductReader.java
@@ -545,7 +545,7 @@ public abstract class Sentinel2OrthoProductReader extends Sentinel2ProductReader
             imageLayout.setTileGridXOffset(0);
             imageLayout.setTileGridYOffset(0);
 
-            RenderingHints hints = new RenderingHints(JAI.KEY_TILE_CACHE,null);
+            RenderingHints hints = new RenderingHints(JAI.KEY_TILE_CACHE, JAI.getDefaultInstance().getTileCache());
             hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout);
 
             RenderedOp mosaicOp = MosaicDescriptor.create(tileImages.toArray(new RenderedImage[tileImages.size()]),
@@ -1381,7 +1381,7 @@ public abstract class Sentinel2OrthoProductReader extends Sentinel2ProductReader
             imageLayout.setTileHeight(S2Config.DEFAULT_JAI_TILE_SIZE);
             imageLayout.setTileGridXOffset(0);
             imageLayout.setTileGridYOffset(0);
-            RenderingHints hints = new RenderingHints(JAI.KEY_TILE_CACHE,null);
+            RenderingHints hints = new RenderingHints(JAI.KEY_TILE_CACHE, JAI.getDefaultInstance().getTileCache());
             hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout);
 
             RenderedOp mosaicOp = MosaicDescriptor.create(tileImages.toArray(new RenderedImage[tileImages.size()]),
@@ -1468,7 +1468,7 @@ public abstract class Sentinel2OrthoProductReader extends Sentinel2ProductReader
             imageLayout.setTileHeight(S2Config.DEFAULT_JAI_TILE_SIZE);
             imageLayout.setTileGridXOffset(0);
             imageLayout.setTileGridYOffset(0);
-            RenderingHints hints = new RenderingHints(JAI.KEY_TILE_CACHE,null);
+            RenderingHints hints = new RenderingHints(JAI.KEY_TILE_CACHE, JAI.getDefaultInstance().getTileCache());
             hints.put(JAI.KEY_IMAGE_LAYOUT, imageLayout);
 
             RenderedOp mosaicOp = MosaicDescriptor.create(tileImages.toArray(new RenderedImage[tileImages.size()]),


### PR DESCRIPTION
The `MosaicOpImages` are the aggregating images of the Sentinel 2 reader and its data should be in the tile cache.

I looked into the runtime of the common use case of taking a Sentinal2 L1C product resampling all bands to 20m and writing it to netCDF. I optimized the code in 2 places: this reader and the `ResamplingOp`. In the `ResamplingOp` I preserved the tile size of the source product. Combining these two changes the runtime (using 2 cores) have improved from roughly 500 seconds to 215 seconds.

I found an older commit, that changes the code to **not** put the `MosaicOpImages` into the tile cache:
- https://github.com/senbox-org/s2tbx/commit/1721182ff3e8873d859e395b944c3cc3db0c6b14
- https://senbox.atlassian.net/browse/SIITBX-241

Signed-off-by: Marco Zuehlke <Marco.Zuehlke@brockmann-consult.de>