### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,12 @@
                 <artifactId>snap-engine</artifactId>
                 <version>${snap.version}</version>
             </dependency>
+          
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-engine-utilities</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.esa.snap</groupId>


### PR DESCRIPTION
Adds snap-engine-utilities dependency. It is needed when ResourceUtils is used when installing default graphs. Therefor needed by multiple modules.