### PR TITLE
Fixed RadiometricIndicesPanel behavior for bands name

### DIFF
--- a/s2tbx-radiometric-indices-ui/src/main/java/org/esa/s2tbx/radiometry/RadiometricIndicesPanel.java
+++ b/s2tbx-radiometric-indices-ui/src/main/java/org/esa/s2tbx/radiometry/RadiometricIndicesPanel.java
@@ -139,12 +139,14 @@ class RadiometricIndicesPanel {
                     BandParameter annotation = field.getAnnotation(BandParameter.class);
                     float min = annotation.minWavelength();
                     float max = annotation.maxWavelength();
-                    if (min != 0.0f && max != 0.0f) {
-                        String bandName = BaseIndexOp.findBand(min, max, this.currentProduct);
-                        try {
-                            property.setValue(bandName);
-                        } catch (ValidationException e) {
-                            e.printStackTrace();
+                    if (property.getValue() == null  || (property.getValue() != null && !this.currentProduct.containsBand(property.getValue()))) {
+                        if (min != 0.0f && max != 0.0f) {
+                            String bandName = BaseIndexOp.findBand(min, max, this.currentProduct);
+                            try {
+                                property.setValue(bandName);
+                            } catch (ValidationException e) {
+                                e.printStackTrace();
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
In the GraphBuilder for operator based on BaseIndexOp when clicking on another tab than the operator, the bands shown in the panel come back to the default value. 