### PR TITLE
Consider tile size when creating multilevel image

### DIFF
--- a/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/ortho/Sentinel2OrthoProductReader.java
+++ b/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/ortho/Sentinel2OrthoProductReader.java
@@ -1289,7 +1289,11 @@ public abstract class Sentinel2OrthoProductReader extends Sentinel2ProductReader
                 dataType = bandInfo.getImageLayout().dataType;
             }
             SampleModel sampleModel = ImageUtils.createSingleBandedSampleModel(dataType, bandRectangle.width, bandRectangle.height);
-            ImageLayout layout = new ImageLayout(0, 0, bandRectangle.width, bandRectangle.height, 0, 0, S2Config.DEFAULT_JAI_TILE_SIZE, S2Config.DEFAULT_JAI_TILE_SIZE, sampleModel, null);
+
+            TileLayout imageLayout = bandInfo.getImageLayout();
+            int tileWidth = imageLayout.tileWidth;
+            int tileHeight = imageLayout.tileHeight;
+            ImageLayout layout = new ImageLayout(0, 0, bandRectangle.width, bandRectangle.height, 0, 0, tileWidth, tileHeight, sampleModel, null);
 
             return new DefaultMultiLevelImage(bandScene, layout);
         }


### PR DESCRIPTION
This is a suggestion to consider the current tile size when creating a multi-level image. This can speed up the reading process. Or is there a reason (which I currently don't know) why the tile size must not be considered in this case?