### PR TITLE
Updated dependencies to use modified JAI library

### DIFF
--- a/s2tbx-coregistration/pom.xml
+++ b/s2tbx-coregistration/pom.xml
@@ -69,6 +69,20 @@
             <groupId>it.geosolutions.jaiext.utilities</groupId>
             <artifactId>jt-utilities</artifactId>
             <version>1.0.13</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_imageio</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
These JAI modules need to be excluded. JAI is already on the classpath.
This is necessary to solve the OpenJDK issue.
