### PR TITLE
Snap 1195 - Fixing menus discrepancies

### DIFF
--- a/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalOp.java
+++ b/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalOp.java
@@ -48,6 +48,7 @@ import java.util.Map;
  */
 @OperatorMetadata(
         alias = "BiophysicalOp",
+        label = "Biophysical Processor (LAI, fAPAR...)",
         category = "Optical/Thematic Land Processing",
         description = "The 'Biophysical Processor' operator retrieves LAI from atmospherically corrected Sentinel-2 products",
         authors = "Julien Malik",

--- a/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
+++ b/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
@@ -33,7 +33,7 @@ import java.util.Map;
 @OperatorMetadata(
         alias = "CoregistrationOp",
         version = "1.0",
-        category = "Raster/Geometric",
+        category = "Raster/Geometric Operations",
         description = "Coregisters two rasters, not considering their location",
         authors = "Ramona M",
         copyright = "Copyright (C) 2017 by CS ROMANIA")

--- a/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
+++ b/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
  */
 @OperatorMetadata(
         alias = "CoregistrationOp",
+        label = "GeFolki Co-registration",
         version = "1.0",
         category = "Raster/Geometric Operations",
         description = "Coregisters two rasters, not considering their location",

--- a/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/ForestCoverChangeOp.java
+++ b/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/ForestCoverChangeOp.java
@@ -75,6 +75,7 @@ import java.util.logging.Logger;
  */
 @OperatorMetadata(
         alias = "ForestCoverChangeOp",
+        label = "Forset Cover Change Operator",
         version="1.0",
         category = "Optical/Thematic Land Processing",
         description = "Creates forrest change masks out of two source products",

--- a/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsDifferenceOp.java
+++ b/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsDifferenceOp.java
@@ -22,7 +22,7 @@ import java.util.Map;
 @OperatorMetadata(
         alias = "BandsDifferenceOp",
         version="1.0",
-        category = "",
+        category = "", // TODO: find correct category or hide it in the graph builder menu
         description = "",
         authors = "Jean Coravu",
         copyright = "Copyright (C) 2017 by CS ROMANIA")

--- a/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsDifferenceOp.java
+++ b/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsDifferenceOp.java
@@ -21,9 +21,10 @@ import java.util.Map;
  */
 @OperatorMetadata(
         alias = "BandsDifferenceOp",
+        label = "Bands Difference",
         version="1.0",
         category = "", // TODO: find correct category or hide it in the graph builder menu
-        description = "",
+        description = "", // I think it should be internal= true
         authors = "Jean Coravu",
         copyright = "Copyright (C) 2017 by CS ROMANIA")
 public class BandsDifferenceOp extends Operator {

--- a/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsExtractorOp.java
+++ b/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsExtractorOp.java
@@ -36,7 +36,7 @@ import java.awt.geom.NoninvertibleTransformException;
 @OperatorMetadata(
         alias = "BandsExtractorOp",
         version="1.0",
-        category = "",
+        category = "Optical",
         description = "Creates a new product out of the source product containing only the indexes bands given",
         authors = "Razvan Dumitrascu",
         copyright = "Copyright (C) 2017 by CS ROMANIA")

--- a/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsExtractorOp.java
+++ b/s2tbx-forest-cover-change/src/main/java/org/esa/s2tbx/fcc/common/BandsExtractorOp.java
@@ -35,6 +35,7 @@ import java.awt.geom.NoninvertibleTransformException;
  */
 @OperatorMetadata(
         alias = "BandsExtractorOp",
+        label = "Bands Extractor",
         version="1.0",
         category = "Optical",
         description = "Creates a new product out of the source product containing only the indexes bands given",

--- a/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
+++ b/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  */
 @OperatorMetadata(
         alias = "GenericRegionMergingOp",
-        label = "Generic region merging processor"
+        label = "Generic region merging processor",
         version="1.0",
         category = "Raster/Segmentation", // "Optical/Thematic Land Processing", 
         description = "The 'Generic Region Merging' operator computes the distinct regions from a product",

--- a/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
+++ b/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
@@ -43,6 +43,7 @@ import java.util.logging.Logger;
  */
 @OperatorMetadata(
         alias = "GenericRegionMergingOp",
+        label = "Generic region merging processor"
         version="1.0",
         category = "Raster/Segmentation", // "Optical/Thematic Land Processing", 
         description = "The 'Generic Region Merging' operator computes the distinct regions from a product",

--- a/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
+++ b/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
 @OperatorMetadata(
         alias = "GenericRegionMergingOp",
         version="1.0",
-        category = "Optical/Thematic Land Processing",
+        category = "Raster/Segmentation", // "Optical/Thematic Land Processing", 
         description = "The 'Generic Region Merging' operator computes the distinct regions from a product",
         authors = "Jean Coravu",
         copyright = "Copyright (C) 2017 by CS ROMANIA")

--- a/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/S2tbxMosaicOp.java
+++ b/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/S2tbxMosaicOp.java
@@ -65,7 +65,7 @@ import java.util.OptionalDouble;
  * @since 5.0.6
  */
 @OperatorMetadata(alias = "Multi-size Mosaic",
-        category = "Raster/Geometric",
+        category = "Raster/Geometric Operations",
         version = "1.0",
         authors = "Razvan Dumitrascu",
         copyright = "(c) 2017 by CS Romania",

--- a/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/S2tbxMosaicOp.java
+++ b/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/S2tbxMosaicOp.java
@@ -65,6 +65,7 @@ import java.util.OptionalDouble;
  * @since 5.0.6
  */
 @OperatorMetadata(alias = "Multi-size Mosaic",
+        label = "Multi-size Mosaic",
         category = "Raster/Geometric Operations",
         version = "1.0",
         authors = "Razvan Dumitrascu",

--- a/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/reproject/S2tbxReprojectionOp.java
+++ b/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/reproject/S2tbxReprojectionOp.java
@@ -124,7 +124,7 @@ import java.util.OptionalDouble;
  * @since 5.0.6
  */
 @OperatorMetadata(alias = "S2tbx-Reproject",
-        category = "Raster/Geometric",
+        category = "Raster/Geometric Operations", // TODO: Check where it is in the main menu 
         version = "1.0",
         authors = "Marco Zühlke, Marco Peters, Ralf Quast, Norman Fomferra, Razvan Dumitrascu",
         copyright = "(c) 2009 by Brockmann Consult, 2017 by CS Romania",

--- a/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/reproject/S2tbxReprojectionOp.java
+++ b/s2tbx-mosaic/src/main/java/org/esa/s2tbx/dataio/mosaic/reproject/S2tbxReprojectionOp.java
@@ -124,6 +124,7 @@ import java.util.OptionalDouble;
  * @since 5.0.6
  */
 @OperatorMetadata(alias = "S2tbx-Reproject",
+        label = "Reprojection",
         category = "Raster/Geometric Operations", // TODO: Check where it is in the main menu 
         version = "1.0",
         authors = "Marco Zühlke, Marco Peters, Ralf Quast, Norman Fomferra, Razvan Dumitrascu",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/ArviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/ArviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "ArviOp",
+        label = "ARVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Atmospherically Resistant Vegetation Index belongs to a family of indices with built-in atmospheric corrections.",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Bi2Op.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Bi2Op.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "Bi2Op",
+        label = "BI2 Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Soil Radiometric Indices",
         description = "The Brightness index represents the average of the brightness of a satellite image.\n" +

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/BiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/BiOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "BiOp",
+        label = "BI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Soil Radiometric Indices",
         description = "The Brightness index represents the average of the brightness of a satellite image.",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/CiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/CiOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "CiOp",
+        label = "CI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Soil Radiometric Indices",
         description = "Colour Index  was developed to differentiate soils in the field.\n" +

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/DviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/DviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "DviOp",
+        label = "DVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Difference Vegetation Index retrieves the Isovegetation lines parallel to soil line",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/GemiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/GemiOp.java
@@ -33,6 +33,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "GemiOp",
+        label = "GEMI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "This retrieves the Global Environmental Monitoring Index (GEMI).",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/GndviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/GndviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "GndviOp",
+        label = "GNDVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Green Normalized Difference Vegetation Index",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/IpviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/IpviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "IpviOp",
+        label = "IPVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Infrared Percentage Vegetation Index retrieves the Isovegetation lines converge at origin",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/IreciOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/IreciOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "IreciOp",
+        label = "IRECI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Inverted red-edge chlorophyll index",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/McariOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/McariOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "McariOp",
+        label = "MCARI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Modified Chlorophyll Absorption Ratio Index, developed to be responsive to chlorophyll variation",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/MndwiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/MndwiOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "MndwiOp",
+        label = "MNDWI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Water Radiometric Indices",
         description = "Modified Normalized Difference Water Index, allowing for the measurement of surface water extent",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Msavi2Op.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Msavi2Op.java
@@ -35,6 +35,7 @@ import java.util.Map;
  */
 @OperatorMetadata(
         alias = "Msavi2Op",
+        label = "MSAVI2 Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "This retrieves the second Modified Soil Adjusted Vegetation Index (MSAVI2).",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/MsaviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/MsaviOp.java
@@ -35,6 +35,7 @@ import java.util.Map;
  */
 @OperatorMetadata(
         alias = "MsaviOp",
+        label = "MSAVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "This retrieves the Modified Soil Adjusted Vegetation Index (MSAVI).",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/MtciOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/MtciOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "MtciOp",
+        label = "MTCI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "The Meris Terrestrial Chlorophyll Index,  aims at estimating the Red Edge Position (REP).\n" +

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Ndi45Op.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Ndi45Op.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "Ndi45Op",
+        label = "NDI45 Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Normalized Difference Index using bands 4 and 5",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/NdpiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/NdpiOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "NdpiOp",
+        label = "NDPI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Water Radiometric Indices",
         description = "The normalized differential pond index, combines the short-wave infrared band-I and the green band",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/NdtiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/NdtiOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "NdtiOp",
+        label = "NDTI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Water Radiometric Indices",
         description = "Normalized difference turbidity index, allowing for the measurement of water turbidity",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Ndwi2Op.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/Ndwi2Op.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "Ndwi2Op",
+        label = "NDWI2 Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Water Radiometric Indices",
         description = "The Normalized Difference Water Index, allowing for the measurement of surface water extent",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/NdwiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/NdwiOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "NdwiOp",
+        label = "NDWI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Water Radiometric Indices",
         description = "The Normalized Difference Water Index was developed for the extraction of water features",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/PssraOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/PssraOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "PssraOp",
+        label = "PSSRA Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Pigment Specific Simple Ratio, chlorophyll index",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/PviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/PviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "PviOp",
+        label = "PVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Perpendicular Vegetation Index retrieves the Isovegetation lines parallel to soil line. Soil line has an arbitrary slope and passes through origin",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/ReipOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/ReipOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "ReipOp",
+        label = "REIP Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "The red edge inflection point index",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/RiOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/RiOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "RiOp",
+        label = "RI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Soil Radiometric Indices",
         description = "The Redness Index was developed to identify soil colour variations.",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/RviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/RviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "RviOp",
+        label = "RVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Ratio Vegetation Index retrieves the Isovegetation lines converge at origin",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/S2repOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/S2repOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "S2repOp",
+        label = "S2REP processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Sentinel-2 red-edge position index",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/SaviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/SaviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "SaviOp",
+        label = "SAVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "This retrieves the Soil-Adjusted Vegetation Index (SAVI).",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/TndviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/TndviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "TndviOp",
+        label = "TNDVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Transformed Normalized Difference Vegetation Index retrieves the Isovegetation lines parallel to soil line",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/TsaviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/TsaviOp.java
@@ -35,6 +35,7 @@ import java.util.Map;
  */
 @OperatorMetadata(
         alias = "TsaviOp",
+        label = "TSAVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "This retrieves the Transformed Soil Adjusted Vegetation Index (TSAVI).",

--- a/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/WdviOp.java
+++ b/s2tbx-radiometric-indices/src/main/java/org/esa/s2tbx/radiometry/WdviOp.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 @OperatorMetadata(
         alias = "WdviOp",
+        label = "WDVI Processor",
         version="1.0",
         category = "Optical/Thematic Land Processing/Vegetation Radiometric Indices",
         description = "Weighted Difference Vegetation Index retrieves the Isovegetation lines parallel to soil line. Soil line has an arbitrary slope and passes through origin",

--- a/s2tbx-reflectance-to-radiance/src/main/java/org/esa/s2tbx/reflectance2radiance/ReflectanceToRadianceOp.java
+++ b/s2tbx-reflectance-to-radiance/src/main/java/org/esa/s2tbx/reflectance2radiance/ReflectanceToRadianceOp.java
@@ -31,7 +31,7 @@ import java.util.Set;
 @OperatorMetadata(
         alias = "ReflectanceToRadianceOp",
         version="1.0",
-        category = "Optical/Thematic Land Processing",
+        category = "Optical/Preprocessing",
         description = "The 'Reflectance To Radiance Processor' operator retrieves the radiance from reflectance using Sentinel-2 products",
         authors = "Dragos Mihailescu",
         copyright = "Copyright (C) 2016 by CS ROMANIA")

--- a/s2tbx-reflectance-to-radiance/src/main/java/org/esa/s2tbx/reflectance2radiance/ReflectanceToRadianceOp.java
+++ b/s2tbx-reflectance-to-radiance/src/main/java/org/esa/s2tbx/reflectance2radiance/ReflectanceToRadianceOp.java
@@ -30,6 +30,7 @@ import java.util.Set;
  */
 @OperatorMetadata(
         alias = "ReflectanceToRadianceOp",
+        label = "Reflectance-To-Radiance Processor",
         version="1.0",
         category = "Optical/Preprocessing",
         description = "The 'Reflectance To Radiance Processor' operator retrieves the radiance from reflectance using Sentinel-2 products",

--- a/s2tbx-s2msi-mci/src/main/java/org/esa/s2tbx/processor/mci/S2MciOp.java
+++ b/s2tbx-s2msi-mci/src/main/java/org/esa/s2tbx/processor/mci/S2MciOp.java
@@ -40,7 +40,7 @@ import org.esa.snap.core.util.converters.BooleanExpressionConverter;
 /**
  * An operator for computing maximum chlorophyll index (MCI) for Sentinel-2 MSI data.
  */
-@OperatorMetadata(alias = "Mci.s2", authors = "Marco Peters", copyright = "Brockmann Consult GmbH",
+@OperatorMetadata(alias = "Mci.s2", label="S2 MCI Processor", authors = "Marco Peters", copyright = "Brockmann Consult GmbH",
                   category = "Optical/Thematic Water Processing",
                   version = "1.0",
                   description = "Computes maximum chlorophyll index (MCI) for Sentinel-2 MSI.")

--- a/s2tbx-s2msi-resampler/src/main/java/org/esa/s2tbx/s2msi/resampler/S2ResamplingOp.java
+++ b/s2tbx-s2msi-resampler/src/main/java/org/esa/s2tbx/s2msi/resampler/S2ResamplingOp.java
@@ -13,6 +13,7 @@ import org.esa.snap.core.gpf.annotations.TargetProduct;
  * Created by obarrile on 05/07/2017.
  */
 @OperatorMetadata(alias = "S2Resampling",
+        label = "S2 Resampling Processor",
         category = "Optical/Geometric",
         authors = "Omar Barrilero",
         version = "1.0",

--- a/s2tbx-spectral-angle-mapper/src/main/java/org/esa/s2tbx/mapper/SpectralAngleMapperOp.java
+++ b/s2tbx-spectral-angle-mapper/src/main/java/org/esa/s2tbx/mapper/SpectralAngleMapperOp.java
@@ -40,6 +40,7 @@ import java.util.concurrent.TimeUnit;
  */
 @OperatorMetadata(
         alias = "SpectralAngleMapperOp",
+        label = "Spectral Angle Mapper Processor",
         version="1.0",
         category = "Geometric/Classification/Supervised Classification",
         description = "Classifies a product using the spectral angle mapper algorithm",

--- a/s2tbx-spectral-angle-mapper/src/main/java/org/esa/s2tbx/mapper/SpectralAngleMapperOp.java
+++ b/s2tbx-spectral-angle-mapper/src/main/java/org/esa/s2tbx/mapper/SpectralAngleMapperOp.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @OperatorMetadata(
         alias = "SpectralAngleMapperOp",
         version="1.0",
-        category = "Optical/Thematic Land Processing",
+        category = "Geometric/Classification/Supervised Classification",
         description = "Classifies a product using the spectral angle mapper algorithm",
         authors = "Dumitrascu Razvan",
         copyright = "Copyright (C) 2017 by CS ROMANIA")


### PR DESCRIPTION
I am trying to uniform the Graph Builder menus with the main window menus, to do so the category in the operator descriptor must be the same as the one in the main menu. 