### PR TITLE
GDAL writer georeferencing bugfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <snap.version>7.0.1-SNAPSHOT</snap.version>
+        <snap.version>7.0.4-SNAPSHOT</snap.version>
         <s2tbx.version>7.0.1-SNAPSHOT</s2tbx.version>
         <geotools.version>17.1</geotools.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -184,6 +184,12 @@
                 <artifactId>ceres-ui</artifactId>
                 <version>${snap.version}</version>
             </dependency>
+            
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>ceres-binding</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.esa.snap</groupId>
@@ -203,6 +209,12 @@
                 <version>${snap.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-core</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+            
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-gpf</artifactId>
@@ -229,12 +241,6 @@
 
             <dependency>
                 <groupId>org.esa.snap</groupId>
-                <artifactId>snap-core</artifactId>
-                <version>${snap.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.esa.snap</groupId>
                 <artifactId>snap-geotiff</artifactId>
                 <version>${snap.version}</version>
             </dependency>
@@ -248,6 +254,42 @@
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-sta-ui</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>ceres-binding</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-bigtiff</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-virtual-file-system</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-ndvi</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-graph-builder</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-binning</artifactId>
                 <version>${snap.version}</version>
             </dependency>
 

--- a/s2tbx-coregistration/pom.xml
+++ b/s2tbx-coregistration/pom.xml
@@ -69,6 +69,25 @@
             <groupId>it.geosolutions.jaiext.utilities</groupId>
             <artifactId>jt-utilities</artifactId>
             <version>1.0.13</version>
+            <!-- required since engine uses the openjdk version -->
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_imageio</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/s2tbx-gdal-reader/src/main/java/org/esa/s2tbx/dataio/gdal/writer/GDALProductWriter.java
+++ b/s2tbx-gdal-reader/src/main/java/org/esa/s2tbx/dataio/gdal/writer/GDALProductWriter.java
@@ -101,8 +101,13 @@ public class GDALProductWriter extends AbstractProductWriter {
         }
 
         final String gdalWriteOptions = Config.instance().preferences().get("snap.dataio.gdal.creationoptions", "");
-        String[] options = StringUtils.stringToArray(gdalWriteOptions, ";");
-        this.gdalDataset = this.gdalDriver.Create(outputFile.toString(), imageWidth, imageHeight, bandCount, this.gdalDataType,options);
+        if (!gdalWriteOptions.isEmpty()) {
+            String[] options = StringUtils.stringToArray(gdalWriteOptions, ";");
+            this.gdalDataset = this.gdalDriver.Create(outputFile.toString(), imageWidth, imageHeight, bandCount, this.gdalDataType, options);
+        }else{
+            this.gdalDataset = this.gdalDriver.Create(outputFile.toString(), imageWidth, imageHeight, bandCount, this.gdalDataType);
+        }
+
         if (this.gdalDataset == null) {
             throw new NullPointerException("Failed creating the file to export the product for driver '" + this.gdalDriver.getLongName() + "'.");
         }

--- a/s2tbx-grm-ui/pom.xml
+++ b/s2tbx-grm-ui/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-kit/pom.xml
+++ b/s2tbx-kit/pom.xml
@@ -378,21 +378,13 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-rcp</artifactId>
-            <version>${project.version}</version>
         </dependency>
         
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-engine-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         
-        <dependency>
-            <groupId>org.esa.snap</groupId>
-            <artifactId>snap-engine-utilities</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-ikonos-reader</artifactId>

--- a/s2tbx-mosaic-ui/pom.xml
+++ b/s2tbx-mosaic-ui/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-mosaic</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -139,7 +139,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-binning</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/s2tbx-mosaic/pom.xml
+++ b/s2tbx-mosaic/pom.xml
@@ -114,12 +114,12 @@
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-commons</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-gdal-reader</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
 

--- a/s2tbx-radiometric-indices-ui/pom.xml
+++ b/s2tbx-radiometric-indices-ui/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-rapideye-reader/pom.xml
+++ b/s2tbx-rapideye-reader/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-gdal-reader</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/s2tbx-reflectance-to-radiance-ui/pom.xml
+++ b/s2tbx-reflectance-to-radiance-ui/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-reflectance-to-radiance/pom.xml
+++ b/s2tbx-reflectance-to-radiance/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.s2tbx</groupId>

--- a/s2tbx-s2msi-resampler/pom.xml
+++ b/s2tbx-s2msi-resampler/pom.xml
@@ -55,16 +55,18 @@
     </dependencies>
     <profiles>
         <profile>
-            <id>oracle-tools</id>
+            <id>jdk-tools</id>
             <activation>
                 <property>
-                    <name>java.vendor</name>
-                    <value>Oracle Corporation</value>
+                    <!-- Maybe this needs to be updated when detecting JDK distributions where
+                    the following does not apply. Currently, it works for the JDKs from Oracle, Adopt, Azul and Amazon-->
+                    <name>java.vm.specification.name</name>
+                    <value>Java Virtual Machine Specification</value>
                 </property>
             </activation>
             <dependencies>
                 <dependency>
-                    <groupId>com.oracle</groupId>
+                    <groupId>com.sun</groupId>
                     <artifactId>tools</artifactId>
                     <version>1.8.0</version>
                     <scope>system</scope>


### PR DESCRIPTION
Pull request to address two issues discussed here:
https://forum.step.esa.int/t/geotiff-bigtiff-export-creates-empty-file/20849

Adds a new java system property:
snap.dataio.gdal.creationoptions
To specify gdal creation options, in the form: "TILED=TRUE;COMPRESS=DEFLATE"

Fixes geocoding, which was simply transferred incorrectly to the gdal dataset.