### PR TITLE
fix dependencies to avoid mixed engine versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,12 @@
                 <artifactId>ceres-ui</artifactId>
                 <version>${snap.version}</version>
             </dependency>
+            
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>ceres-binding</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
 
             <dependency>
                 <groupId>org.esa.snap</groupId>
@@ -203,6 +209,12 @@
                 <version>${snap.version}</version>
             </dependency>
 
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-core</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+            
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-gpf</artifactId>
@@ -229,12 +241,6 @@
 
             <dependency>
                 <groupId>org.esa.snap</groupId>
-                <artifactId>snap-core</artifactId>
-                <version>${snap.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.esa.snap</groupId>
                 <artifactId>snap-geotiff</artifactId>
                 <version>${snap.version}</version>
             </dependency>
@@ -248,6 +254,42 @@
             <dependency>
                 <groupId>org.esa.snap</groupId>
                 <artifactId>snap-sta-ui</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>ceres-binding</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-bigtiff</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-virtual-file-system</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-ndvi</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-graph-builder</artifactId>
+                <version>${snap.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.esa.snap</groupId>
+                <artifactId>snap-binning</artifactId>
                 <version>${snap.version}</version>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <snap.version>7.0.1-SNAPSHOT</snap.version>
+        <snap.version>7.0.4-SNAPSHOT</snap.version>
         <s2tbx.version>7.0.1-SNAPSHOT</s2tbx.version>
         <geotools.version>17.1</geotools.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/s2tbx-coregistration/pom.xml
+++ b/s2tbx-coregistration/pom.xml
@@ -69,6 +69,25 @@
             <groupId>it.geosolutions.jaiext.utilities</groupId>
             <artifactId>jt-utilities</artifactId>
             <version>1.0.13</version>
+            <!-- required since engine uses the openjdk version -->
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_core</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_codec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.media</groupId>
+                    <artifactId>jai_imageio</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>xerces</groupId>
+                    <artifactId>xercesImpl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
     </dependencies>

--- a/s2tbx-grm-ui/pom.xml
+++ b/s2tbx-grm-ui/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-kit/pom.xml
+++ b/s2tbx-kit/pom.xml
@@ -378,21 +378,13 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-rcp</artifactId>
-            <version>${project.version}</version>
         </dependency>
         
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-engine-utilities</artifactId>
-            <version>${project.version}</version>
         </dependency>
         
-        <dependency>
-            <groupId>org.esa.snap</groupId>
-            <artifactId>snap-engine-utilities</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-ikonos-reader</artifactId>

--- a/s2tbx-mosaic-ui/pom.xml
+++ b/s2tbx-mosaic-ui/pom.xml
@@ -130,7 +130,7 @@
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-mosaic</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -139,7 +139,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-binning</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/s2tbx-mosaic/pom.xml
+++ b/s2tbx-mosaic/pom.xml
@@ -114,12 +114,12 @@
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-commons</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-gdal-reader</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
         </dependency>
 
 

--- a/s2tbx-radiometric-indices-ui/pom.xml
+++ b/s2tbx-radiometric-indices-ui/pom.xml
@@ -68,7 +68,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-rapideye-reader/pom.xml
+++ b/s2tbx-rapideye-reader/pom.xml
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.esa.s2tbx</groupId>
             <artifactId>s2tbx-gdal-reader</artifactId>
-            <version>7.0.1-SNAPSHOT</version>
+            <version>${project.version}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/s2tbx-reflectance-to-radiance-ui/pom.xml
+++ b/s2tbx-reflectance-to-radiance-ui/pom.xml
@@ -50,7 +50,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-reflectance-to-radiance/pom.xml
+++ b/s2tbx-reflectance-to-radiance/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.s2tbx</groupId>


### PR DESCRIPTION
The pom.xml files of individual s2tbx modules sometimes refer to ${snap.version}, sometimes to ${project.version}, and sometimes to 7.0.1-SNAPSHOT, even for dependencies to snap-engine. This leads to inconsistent transitive dependencies, among them NetCDF. We need to fix this for Calvalus and propose to cleanup pom.xml files of modules. Versions can all be stated in the parent pom.xml .