### PR TITLE
Moved classes to snap core

### DIFF
--- a/lib-gdal/src/main/java/org/esa/s2tbx/dataio/gdal/GDALDistributionInstaller.java
+++ b/lib-gdal/src/main/java/org/esa/s2tbx/dataio/gdal/GDALDistributionInstaller.java
@@ -1,7 +1,7 @@
 package org.esa.s2tbx.dataio.gdal;
 
 import org.esa.s2tbx.jni.EnvironmentVariables;
-import org.esa.snap.utils.NativeLibraryUtils;
+import org.esa.snap.core.util.NativeLibraryUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/lib-gdal/src/main/java/org/esa/s2tbx/dataio/gdal/GDALInstaller.java
+++ b/lib-gdal/src/main/java/org/esa/s2tbx/dataio/gdal/GDALInstaller.java
@@ -16,11 +16,11 @@
 
 package org.esa.s2tbx.dataio.gdal;
 
+import org.esa.snap.core.util.NativeLibraryUtils;
 import org.esa.snap.core.util.StringUtils;
 import org.esa.snap.core.util.io.FileUtils;
 import org.esa.snap.engine_utilities.file.FileHelper;
 import org.esa.snap.runtime.Config;
-import org.esa.snap.utils.NativeLibraryUtils;
 
 import java.io.File;
 import java.io.IOException;

--- a/s2tbx-commons/src/main/java/org/esa/snap/utils/NativeLibraryUtils.java
+++ b/s2tbx-commons/src/main/java/org/esa/snap/utils/NativeLibraryUtils.java
@@ -22,9 +22,11 @@ import java.util.stream.Collectors;
 /**
  * Helper methods for native libraries registration.
  *
- * @author  Cosmin Cara
- * @since   5.0.0
+ * @author Cosmin Cara
+ * @since 5.0.0
+ * @deprecated since 8.0.0, use {@link org.esa.snap.core.util.NativeLibraryUtils} instead
  */
+@Deprecated()
 public class NativeLibraryUtils {
     private static final String ENV_LIB_PATH = "java.library.path";
 

--- a/s2tbx-commons/src/main/java/org/esa/snap/utils/PrivilegedAccessor.java
+++ b/s2tbx-commons/src/main/java/org/esa/snap/utils/PrivilegedAccessor.java
@@ -40,7 +40,9 @@ import java.lang.reflect.Method;
  * @author Charlie Hubbard (chubbard@iss.net)
  * @author Prashant Dhokte (pdhokte@iss.net)
  * @author Dale Anson (danson@germane-software.com)
+ * @deprecated since 8.0.0, use {@link org.esa.snap.core.util.PrivilegedAccessor} instead
  */
+@Deprecated
 public class PrivilegedAccessor {
     /**
      * Gets the value of the named field and returns it as an object.

--- a/s2tbx-coregistration-ui/src/main/java/org/esa/s2tbx/coregistration/CoregistrationTargetProductDialog.java
+++ b/s2tbx-coregistration-ui/src/main/java/org/esa/s2tbx/coregistration/CoregistrationTargetProductDialog.java
@@ -14,8 +14,8 @@ import org.esa.snap.core.gpf.ui.DefaultIOParametersPanel;
 import org.esa.snap.core.gpf.ui.DefaultSingleTargetProductDialog;
 import org.esa.snap.core.gpf.ui.SourceProductSelector;
 import org.esa.snap.core.gpf.ui.TargetProductSelectorModel;
+import org.esa.snap.core.util.PrivilegedAccessor;
 import org.esa.snap.ui.AppContext;
-import org.esa.snap.utils.PrivilegedAccessor;
 
 import java.lang.reflect.Method;
 import java.util.List;


### PR DESCRIPTION
I've moved the classes NativeLibraryUtils and PrivilegedAccessor into snap-core (package org.esa.snap.core.util). We can make use of it in some other module.
In this pull request, I have modified your code that the new classes in snap-core are used. The old classes I've deprecated.
