### PR TITLE
dependency issue in some modules

### DIFF
--- a/s2tbx-alosAV2-reader/pom.xml
+++ b/s2tbx-alosAV2-reader/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.parsers</groupId>
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-alosPRI-reader/pom.xml
+++ b/s2tbx-alosPRI-reader/pom.xml
@@ -45,7 +45,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.parsers</groupId>

--- a/s2tbx-commons/pom.xml
+++ b/s2tbx-commons/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>

--- a/s2tbx-gdal-reader/pom.xml
+++ b/s2tbx-gdal-reader/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-grm-ui/pom.xml
+++ b/s2tbx-grm-ui/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-grm/pom.xml
+++ b/s2tbx-grm/pom.xml
@@ -56,7 +56,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/s2tbx-ikonos-reader/pom.xml
+++ b/s2tbx-ikonos-reader/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-jp2-writer/pom.xml
+++ b/s2tbx-jp2-writer/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>lib-openjpeg</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/s2tbx-kit/pom.xml
+++ b/s2tbx-kit/pom.xml
@@ -372,13 +372,13 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-rcp</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-engine-utilities</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
 
         <dependency>

--- a/s2tbx-muscate-reader/pom.xml
+++ b/s2tbx-muscate-reader/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>lib-openjpeg</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.parsers</groupId>
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-pleiades-reader/pom.xml
+++ b/s2tbx-pleiades-reader/pom.xml
@@ -113,7 +113,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-pleiades-reader/pom.xml
+++ b/s2tbx-pleiades-reader/pom.xml
@@ -62,17 +62,16 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>lib-openjpeg</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-geotiff</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>

--- a/s2tbx-radiometric-indices-ui/pom.xml
+++ b/s2tbx-radiometric-indices-ui/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-reflectance-to-radiance-ui/pom.xml
+++ b/s2tbx-reflectance-to-radiance-ui/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/s2tbx-reflectance-to-radiance/pom.xml
+++ b/s2tbx-reflectance-to-radiance/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>ceres-binding</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.s2tbx</groupId>

--- a/s2tbx-s2msi-reader/pom.xml
+++ b/s2tbx-s2msi-reader/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.xerial</groupId>
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>lib-openjpeg</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-spot-reader/pom.xml
+++ b/s2tbx-spot-reader/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-spot6-reader/pom.xml
+++ b/s2tbx-spot6-reader/pom.xml
@@ -62,12 +62,12 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>lib-openjpeg</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-jp2-reader</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
         </dependency>
         <dependency>
             <groupId>org.esa.snap</groupId>
@@ -105,7 +105,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-worldview2-reader/pom.xml
+++ b/s2tbx-worldview2-reader/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/s2tbx-worldview2esa-reader/pom.xml
+++ b/s2tbx-worldview2esa-reader/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.esa.snap</groupId>
             <artifactId>snap-runtime</artifactId>
-            <version>${project.version}</version>
+            <version>${snap.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Dependencies to snap should use snap.version variable in the pom and not project.version. Using project.version causes wrong version of SNAP to be included. Here 8.0.2-SNAPSHOT, but actually it should be 8.0.4-SNAPSHOT.
I've corrected this for two modules.
Can you check the other modules if there is the same issue, please?
Please migrate the changes also to the master.