### PR TITLE
Refactored S2CacheActivator

### DIFF
--- a/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheActivator.java
+++ b/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheActivator.java
@@ -58,12 +58,6 @@ public class S2CacheActivator implements Activator {
 
     @Override
     public void stop() {
-        final Preferences preferences = Config.instance("s2tbx").load().preferences();
-        String cachePolicy = preferences.get(S2CacheUtils.SENTINEL_2_CACHE_MAX_TIME, null);
-        if (S2CacheUtils.SENTINEL_2_CACHE_OPTION_EACH_START_UP.equals(cachePolicy)) {
-            S2CacheUtils.deleteCache();
-        }
-
         S2CacheSizeChecking sizeCacheCheckingLoop = S2CacheSizeChecking.getInstance();
         sizeCacheCheckingLoop.complete();
     }

--- a/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheActivator.java
+++ b/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheActivator.java
@@ -60,12 +60,10 @@ public class S2CacheActivator implements Activator {
     public void stop() {
         final Preferences preferences = Config.instance("s2tbx").load().preferences();
         String cachePolicy = preferences.get(S2CacheUtils.SENTINEL_2_CACHE_MAX_TIME, null);
-        if (cachePolicy == null) {
-            return;
-        }
-        if (cachePolicy.equals(S2CacheUtils.SENTINEL_2_CACHE_OPTION_EACH_START_UP)) {
+        if (S2CacheUtils.SENTINEL_2_CACHE_OPTION_EACH_START_UP.equals(cachePolicy)) {
             S2CacheUtils.deleteCache();
         }
+
         S2CacheSizeChecking sizeCacheCheckingLoop = S2CacheSizeChecking.getInstance();
         sizeCacheCheckingLoop.complete();
     }

--- a/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheActivator.java
+++ b/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheActivator.java
@@ -66,6 +66,8 @@ public class S2CacheActivator implements Activator {
         if (cachePolicy.equals(S2CacheUtils.SENTINEL_2_CACHE_OPTION_EACH_START_UP)) {
             S2CacheUtils.deleteCache();
         }
+        S2CacheSizeChecking sizeCacheCheckingLoop = S2CacheSizeChecking.getInstance();
+        sizeCacheCheckingLoop.complete();
     }
 
 }

--- a/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheSizeChecking.java
+++ b/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheSizeChecking.java
@@ -50,7 +50,7 @@ public class S2CacheSizeChecking {
                     double circularLimitSizeCache = limitSizeCache * (1 - releasedSpacePercent);
                     if (currentCacheSize > limitSizeCache) {
                         while (currentCacheSize > circularLimitSizeCache) {
-                            File oldestFile = S2CacheUtils.getOldestFolder();
+                            File oldestFolder = S2CacheUtils.getOldestFolder();
                             if (oldestFile != null) {
                                 S2CacheUtils.deleteFile(oldestFile);
                             }

--- a/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheSizeChecking.java
+++ b/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheSizeChecking.java
@@ -13,6 +13,8 @@ public class S2CacheSizeChecking {
     private static final Logger logger = Logger.getLogger(S2CacheSizeChecking.class.getName());
     private boolean checkingEnable;
     private double limitSizeCache;
+    private ThreadExecutor executor;
+
     private S2CacheSizeChecking(){
         //nothing to init
     }
@@ -20,6 +22,7 @@ public class S2CacheSizeChecking {
     public static S2CacheSizeChecking getInstance() {
         return INSTANCE;
     }
+
     /**
      * set the parameters of the cache size checking
      *
@@ -37,7 +40,7 @@ public class S2CacheSizeChecking {
      * @param period The period between two size checking in minute
      */
     public synchronized void launchCacheSizeChecking(double releasedSpacePurcent, int period) {
-        final ThreadExecutor executor = new ThreadExecutor();
+        executor = new ThreadExecutor();
             try {
                 ThreadRunnable runnable = new ThreadRunnable() {
                     @Override
@@ -63,7 +66,16 @@ public class S2CacheSizeChecking {
                 };
                 executor.execute(runnable);
             } catch (Exception ex) {
-                logger.log(Level.SEVERE, "Failed to initialize S2Cache options."+ex.getMessage());
+                logger.log(Level.SEVERE, "Failed to initialize S2Cache options.",ex);
             }
     }
+
+    public void complete() {
+        try {
+            executor.complete();
+        } catch (Exception e) {
+            logger.log(Level.SEVERE, "Failed to close the sizeCacheChecking: ",e);
+        }
+    }
+
 }

--- a/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheSizeChecking.java
+++ b/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheSizeChecking.java
@@ -1,11 +1,12 @@
 package org.esa.s2tbx.dataio.cache;
 
 import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.esa.snap.core.util.ThreadExecutor;
-import org.esa.snap.core.util.ThreadRunnable;
 
 public class S2CacheSizeChecking {
 
@@ -13,21 +14,22 @@ public class S2CacheSizeChecking {
     private static final Logger logger = Logger.getLogger(S2CacheSizeChecking.class.getName());
     private boolean checkingEnable;
     private double limitSizeCache;
-    private ThreadExecutor executor;
+    private final ScheduledExecutorService executor;
+    private static final double BYTE_TO_GIGA_BYTE = 0.000000001;
 
-    private S2CacheSizeChecking(){
-        //nothing to init
+    private S2CacheSizeChecking() {
+        executor = Executors.newSingleThreadScheduledExecutor();
     }
-    
+
+
     public static S2CacheSizeChecking getInstance() {
         return INSTANCE;
     }
 
     /**
      * set the parameters of the cache size checking
-     *
      */
-    public synchronized void setParameters(boolean checkingEnable,double limitSizeCache ) {
+    public synchronized void setParameters(boolean checkingEnable, double limitSizeCache) {
         this.checkingEnable = checkingEnable;
         this.limitSizeCache = limitSizeCache;
     }
@@ -36,45 +38,43 @@ public class S2CacheSizeChecking {
      * Method check the S2cache size over time. The method is executed in thread.
      * Each period time, the cache size is checked.
      * The x% of the oldest files should be deleted in case of cache oversize.
-     * @param releasedSpacePurcent The space purcentage of the oldest files should be deleted
-     * @param period The period between two size checking in minute
+     *
+     * @param releasedSpacePercent The space percentage of the oldest files should be deleted
+     * @param period               The period between two size checking in minute
      */
-    public synchronized void launchCacheSizeChecking(double releasedSpacePurcent, int period) {
-        executor = new ThreadExecutor();
-            try {
-                ThreadRunnable runnable = new ThreadRunnable() {
-                    @Override
-                    public void process() throws Exception {
-                        double byteToGigaByte = 0.000000001;
-                        while(!Thread.currentThread().isInterrupted()){
-                            if(checkingEnable){
-                                double currentCacheSize = S2CacheUtils.getCacheSize()*byteToGigaByte;
-                                //compute the limit of cache size should be keep after the checking
-                                double circularLimitSizeCache = limitSizeCache * (1-releasedSpacePurcent);
-                                if(currentCacheSize>limitSizeCache){
-                                    while(currentCacheSize>circularLimitSizeCache)
-                                    {
-                                        File oldestFile = S2CacheUtils.getOldestFolder();
-                                        S2CacheUtils.deleteFile(oldestFile);
-                                        currentCacheSize = S2CacheUtils.getCacheSize() * byteToGigaByte;
-                                    }
-                                }
+    public synchronized void launchCacheSizeChecking(double releasedSpacePercent, int period) {
+        Runnable runnable = () -> {
+                if (checkingEnable) {  // would be better if the executor is stopped when the parameter changes
+                    double currentCacheSize = S2CacheUtils.getCacheSize() * BYTE_TO_GIGA_BYTE;
+                    //compute the limit of cache size should be keep after the checking
+                    double circularLimitSizeCache = limitSizeCache * (1 - releasedSpacePercent);
+                    if (currentCacheSize > limitSizeCache) {
+                        while (currentCacheSize > circularLimitSizeCache) {
+                            File oldestFile = S2CacheUtils.getOldestFolder();
+                            if (oldestFile != null) {
+                                S2CacheUtils.deleteFile(oldestFile);
                             }
-                            Thread.sleep((long)period*20000);
+                            currentCacheSize = S2CacheUtils.getCacheSize() * BYTE_TO_GIGA_BYTE;
                         }
                     }
-                };
-                executor.execute(runnable);
-            } catch (Exception ex) {
-                logger.log(Level.SEVERE, "Failed to initialize S2Cache options.",ex);
-            }
+                }
+        };
+        try {
+            executor.scheduleAtFixedRate(runnable, 0, period, TimeUnit.MINUTES);
+        } catch (RejectedExecutionException e) {
+            logger.log(Level.WARNING, "Failed to start observer of S2 Data Cache: ", e);
+        }
+
     }
 
     public void complete() {
         try {
-            executor.complete();
+            executor.shutdown();
+            if(!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+                logger.log(Level.SEVERE, "Failed to stop observer of S2 Data Cache.");
+            }
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Failed to close the sizeCacheChecking: ",e);
+            logger.log(Level.WARNING, "Failed to stop observer of S2 Data Cache: ", e);
         }
     }
 

--- a/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheUtils.java
+++ b/s2tbx-cache/src/main/java/org/esa/s2tbx/dataio/cache/S2CacheUtils.java
@@ -40,10 +40,10 @@ public class S2CacheUtils {
         }
     }
 
-    public static void deleteFile(final File file) {
+    public static void deleteFiles(final File file) {
         if (file.isDirectory()) {
             for (String aChild : file.list()) {
-                deleteFile(new File(file, aChild));
+                deleteFiles(new File(file, aChild));
             }
         }
         try {
@@ -58,13 +58,13 @@ public class S2CacheUtils {
         for (int i = 0; i < files.size(); i++) {
             File file = files.get(i);
             if (file == null) continue;
-            deleteFile(file);
+            deleteFiles(file);
         }
     }
 
     public static void deleteCache() {
         try {
-            deleteFile(getSentinel2CacheFolder());
+            deleteFiles(getSentinel2CacheFolder());
         } catch (Exception e) {
             return;
         }
@@ -100,7 +100,7 @@ public class S2CacheUtils {
      * @param file
      * @return OL if it is not possible to compute, in other case size in bytes
      */
-    public static long getFileSize(File file) {
+    public static long getFilesSize(File file) {
         if (file == null) return 0L;
         if (file.isFile()) return file.length();
         if (!file.isDirectory()) return 0L;
@@ -114,14 +114,14 @@ public class S2CacheUtils {
             if (subFile.isFile())
                 size += subFile.length();
             else
-                size += getFileSize(subFile);
+                size += getFilesSize(subFile);
         }
 
         return size;
     }
 
     public static long getCacheSize() {
-        return getFileSize(getSentinel2CacheFolder());
+        return getFilesSize(getSentinel2CacheFolder());
     }
 
     /**
@@ -153,7 +153,7 @@ public class S2CacheUtils {
                 if (products == null) continue;
                 for (File product : products) {
                     if (product == null) continue;
-                    aux = getFileSize(product);
+                    aux = getFilesSize(product);
                     if (aux > size) {
                         size = aux;
                         largestFile = product;
@@ -194,7 +194,7 @@ public class S2CacheUtils {
                 if (products == null) continue;
                 for (File product : products) {
                     if (product == null) continue;
-                    if (getFileSize(product) > bytes) {
+                    if (getFilesSize(product) > bytes) {
                         largestFile.add(product);
                     }
                 }

--- a/s2tbx-s2msi-resampler/pom.xml
+++ b/s2tbx-s2msi-resampler/pom.xml
@@ -57,6 +57,8 @@
         <profile>
             <id>jdk-tools</id>
             <activation>
+                <!-- tools.jar is only necessary in Java 8. Since Java 9 it is integrated into the JDK. -->
+                <jdk>1.8</jdk>
                 <property>
                     <!-- Maybe this needs to be updated when detecting JDK distributions where
                     the following does not apply. Currently, it works for the JDKs from Oracle, Adopt, Azul and Amazon-->


### PR DESCRIPTION

- using Executors.newSingleThreadScheduledExecutor() instead of ThreadExecuter, removes the need for busy-waiting by Thread.sleep()
- introduced constant BYTE_TO_GIGA_BYTE
- prevent NPE by checking oldestFile for null
- typo Purcent -> Percent
- corrected time period calculation
- optimize the file size calculation
- remove delete file at shutdown snap-engine

