### PR TITLE
SIITBX-357_fix_tiepointgrids

### DIFF
--- a/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/Sentinel2ProductReader.java
+++ b/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/Sentinel2ProductReader.java
@@ -28,6 +28,8 @@ import org.esa.snap.core.dataio.ProductReaderPlugIn;
 import org.esa.snap.core.dataio.ProductSubsetDef;
 import org.esa.snap.core.datamodel.Band;
 import org.esa.snap.core.datamodel.Product;
+import org.esa.snap.core.datamodel.ProductData;
+import org.esa.snap.core.datamodel.TiePointGrid;
 import org.esa.snap.core.datamodel.quicklooks.Quicklook;
 import org.esa.snap.core.image.BandMatrixCell;
 import org.esa.snap.core.image.ImageManager;
@@ -53,6 +55,8 @@ import java.util.List;
 import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import com.bc.ceres.core.ProgressMonitor;
 
 import static org.esa.snap.lib.openjpeg.utils.OpenJpegUtils.validateOpenJpegExecutables;
 

--- a/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/l1c/metadata/S2L1cProductMetadataReader.java
+++ b/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/l1c/metadata/S2L1cProductMetadataReader.java
@@ -50,6 +50,8 @@ public class S2L1cProductMetadataReader extends AbstractS2OrthoMetadataReader {
                 bandNames[1] = S2BandConstants.B9.getFilenameBandId();
                 bandNames[2] = S2BandConstants.B10.getFilenameBandId();
                 break;
+            case R15M:bandNames = null;break;
+            case R30M:bandNames = null;break;
             default:
                 SystemUtils.LOG.warning("Invalid resolution: " + resolution);
                 bandNames = null;

--- a/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/ortho/Sentinel2OrthoProductReader.java
+++ b/s2tbx-s2msi-reader/src/main/java/org/esa/s2tbx/dataio/s2/ortho/Sentinel2OrthoProductReader.java
@@ -170,6 +170,13 @@ public abstract class Sentinel2OrthoProductReader extends Sentinel2ProductReader
     }
 
     @Override
+    public final void readTiePointGridRasterData(TiePointGrid tpg, int destOffsetX, int destOffsetY,
+                            int destWidth, int destHeight,
+                            ProductData destBuffer, ProgressMonitor pm) throws IOException {
+        // Should never not come here, since we have an OpImage that reads data
+    }
+
+    @Override
     protected final Product readProduct(String defaultProductName, boolean isGranule, S2Metadata metadataHeader,
             INamingConvention namingConvention, ProductSubsetDef subsetDef) throws Exception {
         this.orthoMetadataHeader = (S2OrthoMetadata) metadataHeader;


### PR DESCRIPTION
manage tie-point grid (ECMWF reader)
- manage tie-point grid reading during subprocess operations (subset op...)
- resolve warning resolution (ignore warning for the  Landsat8 L2HF resolutions)

The PR #101 (https://github.com/senbox-org/s2tbx/pull/101) will be reverted before.