### PR TITLE
SIITBX-434: Fix GenericRegionMerging creates empty output in GB and GPT.

### DIFF
--- a/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
+++ b/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
@@ -165,8 +165,8 @@ public class GenericRegionMergingOp extends Operator {
     }
 
     /**
-     * JIRA: SIITBX-434
-     * Processes the tiles and builds the GRM output.
+     * [SIITBX-434] Use doExecute() instead of computeTile() for processing the tiles and building the GRM output.
+     * Reason: If JAI execution threads < nr of processing tiles then deadlock occurs.
      *
      * @param pm A progress monitor to be notified for long-running tasks.
      * @throws OperatorException If an error occurs during computation of the target raster.
@@ -236,8 +236,8 @@ public class GenericRegionMergingOp extends Operator {
     }
 
     /**
-     * JIRA: SIITBX-434
-     * Writes the GRM output on targetTile.
+     * [SIITBX-434] Use computeTile() for writing the GRM output on targetTile.
+     * Reason: If JAI execution threads < nr of processing tiles then deadlock occurs.
      *
      * @param targetBand The target band.
      * @param targetTile The current tile associated with the target band to be computed.

--- a/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
+++ b/s2tbx-grm/src/main/java/org/esa/s2tbx/grm/GenericRegionMergingOp.java
@@ -165,19 +165,8 @@ public class GenericRegionMergingOp extends Operator {
     }
 
     /**
-     * Executes the operator.
-     * <p>
-     * For operators that compute raster data tiles, the method is usually a no-op. Other operators might perform their
-     * main work in this method, e.g. perform some image analysis such as extracting statistics and other features from
-     * data products.
-     * <p>
-     * Don't call this method directly. The framework may call this method
-     * <ol>
-     * <li>once before the very first tile is computed, or</li>
-     * <li>as a result of a call to {@link #execute(ProgressMonitor)}.</li>
-     * </ol>
-     * <p>
-     * The default implementation only progresses the progress monitor.
+     * JIRA: SIITBX-434
+     * Processes the tiles and builds the GRM output.
      *
      * @param pm A progress monitor to be notified for long-running tasks.
      * @throws OperatorException If an error occurs during computation of the target raster.
@@ -246,6 +235,15 @@ public class GenericRegionMergingOp extends Operator {
         }
     }
 
+    /**
+     * JIRA: SIITBX-434
+     * Writes the GRM output on targetTile.
+     *
+     * @param targetBand The target band.
+     * @param targetTile The current tile associated with the target band to be computed.
+     * @param pm         A progress monitor which should be used to determine computation cancellation requests.
+     * @throws OperatorException When error occurs
+     */
     @Override
     public final void computeTile(Band targetBand, Tile targetTile, ProgressMonitor pm) throws OperatorException {
         Rectangle targetRectangle = targetTile.getRectangle();


### PR DESCRIPTION
Fix the problem with GenericRegionMerging which creates empty output in Graph Builder and GPT.
JIRA: [SIITBX-434](https://senbox.atlassian.net/browse/SIITBX-434)