### PR TITLE
Gefolki coregistration was writing as output just the one slave band …

### DIFF
--- a/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
+++ b/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
@@ -142,6 +142,8 @@ public class CoregistrationOp extends Operator {
                     slaveProduct.getName() + " having bands : " + Arrays.toString(slaveProduct.getBandGroup().toArray()));
         }
         try {
+	    pm.beginTask("performing coregistration", levels * radArray.length);
+	    checkForCancellation();
             getLogger().info("Started coregistration of products " + masterProduct.getName()
                     + "(" + masterProduct.getSceneRasterWidth() + "X" + masterProduct.getSceneRasterHeight() + ")"
                     + " and " + slaveProduct.getName()
@@ -341,9 +343,10 @@ public class CoregistrationOp extends Operator {
 
                         Runtime.getRuntime().gc();
                     }
+		    checkForCancellation();
+		    pm.worked(1);
                 }
             }
-
 
             xFactor = (float) sourceSlaveImage.getWidth() / processedSlaveImage.getWidth();
             yFactor = (float) sourceSlaveImage.getHeight() / processedSlaveImage.getHeight();
@@ -376,7 +379,6 @@ public class CoregistrationOp extends Operator {
                     originalSlaveBand.getRasterWidth(),
                     originalSlaveBand.getRasterHeight());
             targetBand.setSourceImage(targetImage);
-            targetProduct.addBand(targetBand);
 
             for (Band b : Arrays.asList(slaveProduct.getBands())) {
                 if (!b.getName().equals(hiddenSlaveBand)) {
@@ -393,6 +395,9 @@ public class CoregistrationOp extends Operator {
                     targetProduct.addBand(btBand);
 
                 }
+		else{
+		    targetProduct.addBand(targetBand);
+		}
             }
 
             getLogger().info("Finished coregistration in " + (System.currentTimeMillis() - startTime) / 1000f + "sec");
@@ -406,6 +411,7 @@ public class CoregistrationOp extends Operator {
                 getLogger().warning("During coregistration operation, temporary cache folder was not deleted!");
             }
         }
+	pm.done();
     }
 
     public static class Spi extends OperatorSpi {

--- a/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
+++ b/s2tbx-coregistration/src/main/java/org/esa/s2tbx/coregistration/CoregistrationOp.java
@@ -389,7 +389,7 @@ public class CoregistrationOp extends Operator {
                             ProductData.TYPE_FLOAT32,
                             b.getRasterWidth(),
                             b.getRasterHeight());
-                    btBand.setSourceImage(targetImage);
+                    btBand.setSourceImage(bImage);
                     targetProduct.addBand(btBand);
 
                 }


### PR DESCRIPTION
…multiple times, instead need to write out all the transformed slave bands

Dear Luis and Team :

thank you so much for all the hard work and the amazing software and science.. SNAP is AWESOME! 
For your consideration:

As you can see from the screen shot of the original code below:
bImage is declared and created, but not used (line 384):

inside the loop over the slave bands:
it looks like bImage is created with the intention that it would be put into btBand, and in turn, added to the output product (targetProduct)

Presently it appears that multiple copies of the same (transformed) band from the slave product (as represented by targetImage) are written to the output: one copy of that same band for each band in the slave product.

I think this update would make it possible to co-register multi-band images (of heterogeneous types for example SAR to optical or vice versa). Thanks v much in advance for having a look and thank you for considering the pull request!

Many thanks
Best regards,
Ashlin

![Screenshot from 2022-06-15 21-18-16](https://user-images.githubusercontent.com/2578004/173991541-118d8282-5ddb-4e3d-80d0-56f39080536e.png)