### PR TITLE
Wrong georeferencing of angles grid in S2Resampler.java?

### DIFF
--- a/s2tbx-s2msi-resampler/src/main/java/org/esa/s2tbx/s2msi/resampler/S2Resampler.java
+++ b/s2tbx-s2msi-resampler/src/main/java/org/esa/s2tbx/s2msi/resampler/S2Resampler.java
@@ -315,7 +315,8 @@ public class S2Resampler implements Resampler {
                                                                      anglesGridByDetector[1].getHeight());
             int extendedWidth = anglesGridByDetector[0].getWidth() + 2;
             int extendedHeight = anglesGridByDetector[0].getHeight() + 2;
-            AffineTransform originalAffineTransform5000 = new AffineTransform(anglesGridByDetector[0].getResolutionX(), 0.0f, 0.0f, -anglesGridByDetector[0].getResolutionX(), anglesGridByDetector[0].originX, anglesGridByDetector[0].originY);
+            float resx = anglesGridByDetector[0].getResolutionX();
+            AffineTransform originalAffineTransform5000 = new AffineTransform(resx, 0.0f, 0.0f, -resx, anglesGridByDetector[0].originX-resx/2, anglesGridByDetector[0].originY+resx/2);
             AffineTransform extendedAffineTransform5000 = (AffineTransform) originalAffineTransform5000.clone();
             extendedAffineTransform5000.translate(-1d,-1d);
             MultiLevelImage zenithMultiLevelImage = S2ResamplerUtils.createMultiLevelImage(extendedZenithData,extendedWidth,extendedHeight,extendedAffineTransform5000);


### PR DESCRIPTION
@marpet Is it possible that there is a mistake in the georeferencing of the grid of angles when converting to image in updateAngleBands ?

Considering the detector footprint gml vector as the truth, the current georeferencing does not seem to align/cover well with the detector footprint. Indeed, it seems to align/center better shifting the upper-left corner by half a pixel.

Below is the detector footprints as a vector (gml) over one of the detector rasters (detectorId=6 in that case). It was taken from band "B02" of scene "S2B_MSIL1C_20181225T092409_N0207_R093_T33NTD_20181225T113038.SAFE"

- current s2tbx georeferencing:

![image](https://github.com/senbox-org/s2tbx/assets/16676897/3eb11197-ed93-4ce0-90ef-9d4001bc2476)

- shifting the UL by half a pixel:

![image](https://github.com/senbox-org/s2tbx/assets/16676897/92881b87-467b-4711-859b-0150ca82615b)


If it is the case, the current PR shifts the origin of the angle image of half a pixel compared to the origin of the angle grid, so that the pixel center coordinates align well with the grid.

I am sorry I did not use the forum for that, but I was not allowed to post as my forum account was new, and I did not find any specification on how to get that permission...
