### PR TITLE
Improve convex hull check

### DIFF
--- a/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalAlgo.java
+++ b/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalAlgo.java
@@ -7,6 +7,7 @@ import com.bc.jnn.JnnNet;
 import com.bc.jnn.JnnUnit;
 
 
+import java.util.Arrays;
 import java.util.HashSet;
 
 /**
@@ -119,18 +120,6 @@ public class BiophysicalAlgo {
         result.setOutputValue(Double.NaN);
     }
 
-    private static Integer hashDomainGridPoint(double[] domainGridPoint){
-        assert domainGridPoint.length <= 9; // prevent rollover of int32
-        int hashCode = 0;
-        for (int i=(domainGridPoint.length-1); i >= 0; i--){
-            int digit = (int)domainGridPoint[i];
-            assert digit >= 1 && digit <= 10;
-            digit -= 1;
-            hashCode += digit * (int)Math.pow(10, i);
-        }
-        return hashCode;
-    }
-
     private void createHasSetDefinition()
     {
         definitionGridSet=null;
@@ -140,8 +129,10 @@ public class BiophysicalAlgo {
             definitionGridSet = new HashSet<>(definitionDomain.length);
             definitionGridSize = definitionDomain[0].length;
             for (int row = 0; row < definitionDomain.length; row++) {
-                double [] definitionDomainEntry = definitionDomain[row];
-                definitionGridSet.add(hashDomainGridPoint(definitionDomainEntry));
+                int[] definitionDomainEntry = Arrays.stream(definitionDomain[row])
+                        .mapToInt(d -> (int) d)
+                        .toArray();
+                definitionGridSet.add(Arrays.hashCode(definitionDomainEntry));
             }
         }
     }
@@ -174,13 +165,13 @@ public class BiophysicalAlgo {
          */
 
         if (bandMinMax != null && definitionGridSet != null) {
-            double[] inputPointProjection = new double[definitionGridSize];
+            int[] inputPointProjection = new int[definitionGridSize];
             for (int i = 0; i < definitionGridSize; i++) {
                 double bandMin = bandMinMax[0][i];
                 double bandMax = bandMinMax[1][i];
-                inputPointProjection[i] = Math.floor(10 * (input[i] - bandMin) / (bandMax - bandMin) + 1);
+                inputPointProjection[i] = (int)Math.floor(10 * (input[i] - bandMin) / (bandMax - bandMin) + 1);
             }
-            if(!definitionGridSet.contains(hashDomainGridPoint(inputPointProjection))){
+            if(!definitionGridSet.contains(Arrays.hashCode(inputPointProjection))){
                 setInputOutOfRange(result);
             }
         }

--- a/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalAlgo.java
+++ b/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalAlgo.java
@@ -168,6 +168,9 @@ public class BiophysicalAlgo {
 
         /*
          * Second check : be sure input is within the approximated convex hull (see ATBD)
+         * the domain of the convex hull was calculated in advance and
+         * the resulting point cloud is stored in DefinitionDomain_Grid.
+         * it contains ALL valid points and NOT the boundaries of the hull.
          */
 
         if (bandMinMax != null && definitionGridSet != null) {

--- a/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalAlgo.java
+++ b/s2tbx-biophysical/src/main/java/org/esa/s2tbx/biophysical/BiophysicalAlgo.java
@@ -7,14 +7,14 @@ import com.bc.jnn.JnnNet;
 import com.bc.jnn.JnnUnit;
 
 
-import java.util.HashMap;
+import java.util.HashSet;
 
 /**
  * Created by jmalik on 20/06/16.
  */
 public class BiophysicalAlgo {
 
-    private HashMap<Integer, String> definitionGridMap;
+    private HashSet<String> definitionGridSet;
     private int definitionGridSize;
 
     public class Result {
@@ -121,11 +121,11 @@ public class BiophysicalAlgo {
 
     private void createHasSetDefinition()
     {
-        definitionGridMap=null;
+        definitionGridSet =null;
         definitionGridSize=0;
         double [][] definitionDomain = this.auxdata.getCoeffs(BiophysicalAuxdata.BiophysicalVariableCoeffs.DEFINITION_DOMAIN_GRID);
         if (definitionDomain != null) {
-            definitionGridMap = new HashMap<>();
+            definitionGridSet = new HashSet<>(definitionDomain.length);
             definitionGridSize = definitionDomain[0].length;
             for (int row = 0; row < definitionDomain.length; row++) {
                 double [] definitionDomainEntry = definitionDomain[row];
@@ -135,7 +135,7 @@ public class BiophysicalAlgo {
                     definitionDomainEntryInt[i] = (int)definitionDomainEntry[i];
                     domainString+=String.valueOf(definitionDomainEntryInt[i]);
                 }
-                definitionGridMap.put(row, domainString);
+                definitionGridSet.add(domainString);
             }
         }
     }
@@ -164,17 +164,16 @@ public class BiophysicalAlgo {
          * Second check : be sure input is within the approximated convex hull (see ATBD)
          */
 
-        if (bandMinMax != null && definitionGridMap != null) {
-            int [] gridProjection = new int[definitionGridSize];
+        if (bandMinMax != null && definitionGridSet != null) {
             String gridProjString="";
-            for (int i = 0; i < gridProjection.length; i++) {
+            for (int i = 0; i < definitionGridSize; i++) {
                 double bandMin = bandMinMax[0][i];
                 double bandMax = bandMinMax[1][i];
-                gridProjection[i] = (int)Math.floor(10 * (input[i] - bandMin) / (bandMax - bandMin) + 1);
-                gridProjString+=String.valueOf(gridProjection[i]);
+                int gridProjection = (int)Math.floor(10 * (input[i] - bandMin) / (bandMax - bandMin) + 1);
+                gridProjString+=String.valueOf(gridProjection);
             }
             boolean insideDefinitionDomain = false;
-            if(definitionGridMap.containsValue(gridProjString)){
+            if(definitionGridSet.contains(gridProjString)){
                 insideDefinitionDomain = true;
             }
             if (!insideDefinitionDomain) {


### PR DESCRIPTION
The current implementation of the convex hull check is inefficient due to the incorrect use of HashMap.
Instead of checking if there is a key O(1) in the set, it checks if the map contains a value O(n).
I think this is an implementation error as [previous commits](https://github.com/senbox-org/s2tbx/commit/c766f1c9fc349d2bb54be61db495924416d33981#diff-4f59a43500d372461d1765cb5eacf9e0304f4e0c828d0ba49839579765055e39R154) mention a HashSet, which makes sense to me.

```Java
/*
 * Second check : be sure input is within the approximated convex hull (see ATBD)
 */

if (bandMinMax != null && definitionGridMap != null) {
    int [] gridProjection = new int[definitionGridSize];
    String gridProjString="";
    for (int i = 0; i < gridProjection.length; i++) {
        double bandMin = bandMinMax[0][i];
        double bandMax = bandMinMax[1][i];
        gridProjection[i] = (int)Math.floor(10 * (input[i] - bandMin) / (bandMax - bandMin) + 1);
        gridProjString+=String.valueOf(gridProjection[i]);
    }
    boolean insideDefinitionDomain = false;
    if(definitionGridMap.containsValue(gridProjString)){  // << here is the problem
        insideDefinitionDomain = true;
    }
    if (!insideDefinitionDomain) {
        setInputOutOfRange(result);
        return;
    }

}
```

I'm also not a fan of converting each domain definition point to a string representation, which will be hashed again to get an int representation. i suggest combining the int array into a single int and using that as a hash instead.

I also added a comment describing how the check works, because it took me a while to figure out that DefinitionDomain_Grid contains all valid points and not the points of the hull boundary (even though ‘Domain’ should have given me the hint).